### PR TITLE
클러스터 준비 및 스토리지 센터 VM배포 마법사에서 UI  버그 수정

### DIFF
--- a/src/features/cluster-config-prepare.js
+++ b/src/features/cluster-config-prepare.js
@@ -687,6 +687,7 @@ async function resetClusterConfigWizardWithData() {
     $('#form-radio-timeserver-ext').prop('checked', true);
     $('#form-radio-timeserver-int').prop('checked', false);
     $('input[name=form-input-cluster-config-timeserver]').val("");
+    $('#div-timeserver-host-num').hide();
     $('#form-radio-timeserver-host-num-1').prop('checked', true);
     $('#form-radio-timeserver-host-num-2').prop('checked', false);
     $('#form-radio-timeserver-host-num-3').prop('checked', false);
@@ -703,7 +704,7 @@ async function resetClusterConfigWizardWithData() {
     $('#button-accordion-timeserver').removeClass("pf-m-expanded");
     $('#div-accordion-timeserver').fadeOut();
     $('#div-accordion-timeserver').removeClass("pf-m-expanded");
-    // 클래스 원복
+    // nav, button등 이벤트에 적용된 속성 원복
     $('#nav-button-cluster-config-finish').addClass('pf-m-disabled');
     $('#nav-button-cluster-config-overview').removeClass('pf-m-disabled');
     $('#nav-button-cluster-config-ssh-key').removeClass('pf-m-disabled');

--- a/src/features/storage-vm-wizard.html
+++ b/src/features/storage-vm-wizard.html
@@ -304,7 +304,7 @@
                                             <input class="pf-c-check__input" style="margin-top:12px;margin-right:5px" type="checkbox" id="form-input-storage-vm-additional-file" name="form-input-storage-vm-additional-file" checked/>
                                             <label class="pf-c-check__label" style="margin-top:8px;margin-left:0px" for="form-input-storage-vm-additional-file">Hosts 파일 사용</label>
                                             <input class="pf-c-form-control" style="width:70%" type="file" id="form-input-storage-vm-hosts-file" name="form-input-storage-vm-hosts-file"/>
-                                            <textarea class="pf-c-form-control" style="width:90%;height:110px;margin-top:10px" type="text" id="form-textarea-storage-vm-hosts-file"></textarea>
+                                            <textarea class="pf-c-form-control tab-available" style="width:90%;height:110px;margin-top:10px" type="text" id="form-textarea-storage-vm-hosts-file"></textarea>
                                         </div>
                                     </div>
                                     <div class="pf-c-form__group">


### PR DESCRIPTION
## 클러스터 준비 및 스토리지 센터 VM배포 마법사에서 UI  버그 수정

#### 연관 이슈 - 클러스터 준비 및 스토리지 센터 VM배포 마법사 UI 수정 #157

- [x] 클러스터 준비 마법사 : 타임서버 단계에서 외부서버 radio버튼 선택한 후 취소를 클릭하면 초기화가 안되는 문제
- [x] 스토리지 센터 VM 마법사 : 추가 네트워크 정보 단계에서 호스트 프로파일 textarea에 tab키 활성화