### PR TITLE
scvm 및 ccvm vmconfig 폴더권한 변경 및 xml 생성로직 수정

### DIFF
--- a/python/vm/create_ccvm_xml.py
+++ b/python/vm/create_ccvm_xml.py
@@ -128,6 +128,17 @@ def createCcvmXml(args):
                         line = line.replace('<!--memory-->', str(args.memory))
                     elif '<!--cpu-->' in line:
                         line = line.replace('<!--cpu-->', str(args.cpu))
+                    elif '<!--ccvm_cloudinit-->' in line:
+                        cci_txt = "    <disk type='file' device='cdrom'>\n"
+                        cci_txt += "      <driver name='qemu' type='raw'/>\n"
+                        cci_txt += "      <source file='"+pluginpath+"/tools/vmconfig/ccvm/ccvm-cloudinit.iso'/>\n"
+                        cci_txt += "      <target dev='hda' bus='ide'/>\n"
+                        cci_txt += "      <readonly/>\n"
+                        cci_txt += "      <shareable/>\n"
+                        cci_txt += "      <address type='drive' controller='0' bus='0' target='0' unit='0'/>\n"
+                        cci_txt += "    </disk>"
+                        
+                        line = line.replace('<!--ccvm_cloudinit-->', cci_txt)
                     elif '<!--management_network_bridge-->' in line:
                         mnb_txt = "    <interface type='bridge'>\n"
                         mnb_txt += "      <mac address='" + generateMacAddress() + "'/>\n"
@@ -161,6 +172,9 @@ def createCcvmXml(args):
                     sys.stdout.write(line)
 
             os.system("scp "+pluginpath+"/tools/vmconfig/ccvm/ccvm-temp.xml root@"+host_name+":"+pluginpath+"/tools/vmconfig/ccvm/ccvm.xml")
+
+            # pcs 클러스터 할 호스트 전체의 폴더 권한 수정
+            os.system("ssh root@"+host_name+" 'chmod 755 -R "+pluginpath+"/tools/vmconfig/ccvm'")
 
         #작업파일 지우기
         os.system("rm -f "+pluginpath+"/tools/vmconfig/ccvm/ccvm-temp.xml "+pluginpath+"/tools/vmconfig/ccvm/ccvm.xml.bak "+pluginpath+"/tools/vmconfig/ccvm/ccvm-temp.xml.bak")

--- a/python/vm/create_scvm_xml.py
+++ b/python/vm/create_scvm_xml.py
@@ -118,6 +118,17 @@ def createScvmXml(args):
                     line = line.replace('<!--memory-->', str(args.memory))
                 elif '<!--cpu-->' in line:
                     line = line.replace('<!--cpu-->', str(args.cpu))
+                elif '<!--scvm_cloudinit-->' in line:
+                    sci_txt = "    <disk type='file' device='cdrom'>\n"
+                    sci_txt += "      <driver name='qemu' type='raw'/>\n"
+                    sci_txt += "      <source file='"+pluginpath+"/tools/vmconfig/scvm/scvm-cloudinit.iso'/>\n"
+                    sci_txt += "      <target dev='hda' bus='ide'/>\n"
+                    sci_txt += "      <readonly/>\n"
+                    sci_txt += "      <shareable/>\n"
+                    sci_txt += "      <address type='drive' controller='0' bus='0' target='0' unit='0'/>\n"
+                    sci_txt += "    </disk>"
+
+                    line = line.replace('<!--scvm_cloudinit-->', sci_txt)
                 elif '<!--lun_passthrough-->' in line:
                     if 'lun_passthrough' == args.disk_type:
                         lpl_txt = ""
@@ -309,6 +320,9 @@ def createScvmXml(args):
         # 작업파일 삭제 및 이름 변경
         os.system("mv "+pluginpath+"/tools/vmconfig/scvm/scvm-temp.xml "+pluginpath+"/tools/vmconfig/scvm/scvm.xml")
         os.system("rm -f "+pluginpath+"/tools/vmconfig/scvm/scvm-temp.xml.bak")
+
+        # 폴더 권한 수정
+        os.system("chmod 755 -R "+pluginpath+"/tools/vmconfig/scvm")
 
         # 결과값 리턴
         return createReturn(code=200, val={})        

--- a/tools/xml-template/ccvm-xml-template.xml
+++ b/tools/xml-template/ccvm-xml-template.xml
@@ -29,14 +29,7 @@
   </pm>
   <devices>
     <emulator>/usr/libexec/qemu-kvm</emulator>
-    <disk type="file" device="cdrom">
-      <driver name="qemu" type="raw"/>
-      <source file="/usr/share/cockpit/ablestack/tools/vmconfig/ccvm/ccvm-cloudinit.iso"/>
-      <target dev="hda" bus="ide"/>
-      <readonly/>
-      <shareable/>
-      <address type="drive" controller="0" bus="0" target="0" unit="0"/>
-    </disk>
+<!--ccvm_cloudinit-->
     <disk type='network' device='disk'>
       <source protocol='rbd' name='rbd/ccvm'>
         <host name='scvm' port='6789'/>

--- a/tools/xml-template/scvm-xml-template.xml
+++ b/tools/xml-template/scvm-xml-template.xml
@@ -29,14 +29,7 @@
   </pm>
   <devices>
     <emulator>/usr/libexec/qemu-kvm</emulator>
-    <disk type="file" device="cdrom">
-      <driver name="qemu" type="raw"/>
-      <source file="/usr/share/cockpit/ablestack/tools/vmconfig/scvm/scvm-cloudinit.iso"/>
-      <target dev="hda" bus="ide"/>
-      <readonly/>
-      <shareable/>
-      <address type="drive" controller="0" bus="0" target="0" unit="0"/>
-    </disk>
+<!--scvm_cloudinit-->
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
       <source file='/var/lib/libvirt/images/scvm.qcow2'/>


### PR DESCRIPTION
#187 #191 

- [x] 폴더권한 755로 변경
- [x] scvm, ccvm xml 생성로직 변경

상세내용
1. usr/share/cockpit/ablestack/tools/vmconfig 폴더에 밑에 배포관련 파일을 생성하는데 권한을 755로 부여
2. scvm 및 ccvm xml 생성시 cloudinit.iso 파일에 대한 정보를 플러그인 경로가 동적으로 적용될수 있도록 적용