### PR TITLE
4차 테스트 scvm, ccvm 배포 마법사 기능 개선

### DIFF
--- a/python/vm/create_ccvm_cloudinit.py
+++ b/python/vm/create_ccvm_cloudinit.py
@@ -59,7 +59,7 @@ def createArgumentParser():
 
     return parser
 
-def resetCloud(args):
+def createCcvmCloudinit(args):
     
     success_bool = True
     
@@ -114,5 +114,5 @@ if __name__ == '__main__':
     logger = createLogger(verbosity=logging.CRITICAL, file_log_level=logging.ERROR, log_file='test.log')
 
     # 실제 로직 부분 호출 및 결과 출력
-    ret = resetCloud(args)
+    ret = createCcvmCloudinit(args)
     print(ret)

--- a/python/vm/create_scvm_cloudinit.py
+++ b/python/vm/create_scvm_cloudinit.py
@@ -55,7 +55,7 @@ def createArgumentParser():
 
     return parser
 
-def resetCloud(args):
+def createScvmCloudinit(args):
     
     success_bool = True
     
@@ -101,5 +101,5 @@ if __name__ == '__main__':
     logger = createLogger(verbosity=logging.CRITICAL, file_log_level=logging.ERROR, log_file='test.log')
 
     # 실제 로직 부분 호출 및 결과 출력
-    ret = resetCloud(args)
+    ret = createScvmCloudinit(args)
     print(ret)

--- a/python/vm/host_ping_test.py
+++ b/python/vm/host_ping_test.py
@@ -13,6 +13,7 @@ import sys
 import os
 
 from ablestack import *
+from sh import python3
 
 def createArgumentParser():
     '''
@@ -60,21 +61,9 @@ def hostPingTest(args):
             ret_val.append(item)
 
         # ex : ssh root@host echo 명령을 수행시 인증이 되어있으면 바로 응답이 오는데 인증이 되어있지 않으면 정상응답이 오지 않음
-        if ret_text == "" : # ping test 성공 후 ssh 명령시 yes/no 핑거 프린트 부문 해결을 위해 실행하는 호스트에서 pcs 구성할 1,2,3 호스트에 1회씩 echo 명령어 수행하여 known_hosts에 등록
-            for host in args.host_names:
-                item = {}
-                ssh_check = os.system("ssh -o StrictHostKeyChecking=no root@"+ host + " echo > /dev/null")
+        # 핑거프린트 해결을 위해 ssh-scan.py 호출
+        python3(pluginpath+'/python/host/ssh-scan.py')
 
-                if ssh_check == 0 :
-                    item["host"] = host
-                    item["status"] = 'ssh test ok'
-                else:
-                    item["host"] = host
-                    item["status"] = 'ssh test fail'
-                    ret_text += host+"와 SSH 접속 테스트 실패하였습니다\n"
-
-                ret_val.append(item)
-        
         if ret_text == "":
             return createReturn(code=200, val="host ping test success")
         else:

--- a/python/vm/reset_cloud_center.py
+++ b/python/vm/reset_cloud_center.py
@@ -44,7 +44,7 @@ def createArgumentParser():
 
     return parser
 
-def resetCloud(args):
+def resetCloudCenter(args):
     
     success_bool = True
 
@@ -109,5 +109,5 @@ if __name__ == '__main__':
     logger = createLogger(verbosity=logging.CRITICAL, file_log_level=logging.ERROR, log_file='test.log')
 
     # 실제 로직 부분 호출 및 결과 출력
-    ret = resetCloud(args)
+    ret = resetCloudCenter(args)
     print(ret)

--- a/python/vm/setup_pcs_cluster.py
+++ b/python/vm/setup_pcs_cluster.py
@@ -45,7 +45,7 @@ def createArgumentParser():
 
     return parser
 
-def resetCloud(args):
+def setupPcsCluster(args):
     
     success_bool = True
 
@@ -96,5 +96,5 @@ if __name__ == '__main__':
     logger = createLogger(verbosity=logging.CRITICAL, file_log_level=logging.ERROR, log_file='test.log')
 
     # 실제 로직 부분 호출 및 결과 출력
-    ret = resetCloud(args)
+    ret = setupPcsCluster(args)
     print(ret)

--- a/python/vm/setup_storage_vm.py
+++ b/python/vm/setup_storage_vm.py
@@ -40,7 +40,7 @@ def createArgumentParser():
 
     return parser
 
-def resetCloud(args):
+def setupStorageVm(args):
 
     success_bool = True    
     
@@ -78,5 +78,5 @@ if __name__ == '__main__':
     logger = createLogger(verbosity=logging.CRITICAL, file_log_level=logging.ERROR, log_file='test.log')
 
     # 실제 로직 부분 호출 및 결과 출력
-    ret = resetCloud(args)
+    ret = setupStorageVm(args)
     print(ret)

--- a/src/features/cloud-vm-wizard.js
+++ b/src/features/cloud-vm-wizard.js
@@ -1101,76 +1101,76 @@ function setCcvmReviewInfo(){
  */
 function validateCloudCenterVm(){
 
-    var valicateCheck = true;
+    var valicate_check = true;
 
     var svc_bool = $('input[type=checkbox][id="form-checkbox-svc-network"]').is(":checked");
 
     if($('#form-input-cloud-vm-failover-cluster-host1-name').val() == ""){ //host1 name
         alert("클러스터 호스트1의 이름을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ($('#form-input-cloud-vm-failover-cluster-host2-name').val() == "") { //host2 name
         alert("클러스터 호스트2의 이름을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ($('#form-input-cloud-vm-failover-cluster-host3-name').val() == "") { //host3 name
         alert("클러스터 호스트3의 이름을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ($('select#form-select-cloud-vm-compute-cpu-core option:checked').val() == "") { //cpu
         alert("CPU core를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ($('select#form-select-cloud-vm-compute-memory option:checked').val() == "") { //memory
         alert("Memory를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ($('select#form-select-cloud-vm-mngt-parent option:checked').val() == "") { //관리용 bridge
         alert("관리용네트워크를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if (svc_bool && $('select#form-select-cloud-vm-svc-parent option:checked').val() == "") {//서비스용 bridge
         alert("서비스네트워크를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ($('#form-textarea-cloud-vm-hosts-file').val() == "") { //hosts 파일
         alert("Hosts 파일을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ($('#form-input-cloud-vm-hostname').val() == "") { //클라우드센터 가상머신 호스트명
         alert("클라우드센터 가상머신의 호스트명 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ($('#form-input-cloud-vm-mngt-nic-ip').val() == "") { //관리 NIC IP
         alert("관리 NIC IP를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ($('#form-input-cloud-vm-mngt-gw').val() == "") { //관리 NIC Gateway
         alert("관리 NIC Gateway를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if (svc_bool && $('#form-input-cloud-vm-svc-nic-ip').val() == "") { //서비스 NIC IP
         alert("서비스 NIC IP를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if (svc_bool && $('#form-input-cloud-vm-svc-gw').val() == "") { //서비스 NIC Gateway
         alert("서비스 NIC Gateway를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ( $('#form-textarea-cloud-vm-ssh-private-key-file').val() == "") { //SSH 개인 Key 정보
         alert("SSH 개인 Key 파일을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if ( $('#form-textarea-cloud-vm-ssh-public-key-file').val() == "") { //SSH 공개 Key 정보
         alert("SSH 공개 Key 파일을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if(!checkHostFormat($("#form-input-cloud-vm-hostname").val())){
         alert("호스트명 입력 형식을 확인해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if(!checkCidrFormat($("#form-input-cloud-vm-mngt-nic-ip").val())){
         alert("관리 NIC IP 형식을 확인해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if(!checkIp($("#form-input-cloud-vm-mngt-gw").val())){
         alert("관리 NIC Gateway 형식을 확인해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if(svc_bool && !checkCidrFormat($("#form-input-cloud-vm-svc-nic-ip").val())){
         alert("서비스 NIC IP 형식을 확인해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if(svc_bool && !checkIp($("#form-input-cloud-vm-svc-gw").val())){
         alert("서비스 NIC Gateway 형식을 확인해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     } else if(!checkSpace($("#form-textarea-cloud-vm-hosts-file").val())){
         alert("Hosts 파일 작성 시 'Tab 키'만 사용 가능합니다.");
-        valicateCheck = false;
+        valicate_check = false;
     }
 
-    return valicateCheck;
+    return valicate_check;
 }
 
 /**

--- a/src/features/storage-vm-wizard.js
+++ b/src/features/storage-vm-wizard.js
@@ -1139,10 +1139,10 @@ function validateStorageVm(){
     }else if(svnt != "npb" && $('select#form-select-storage-vm-cluster-nic1 option:checked').val() == ""){
         alert("복제용 NIC 1번을 입력해주세요.");
         valicate_check = false;
-    }else if(svnt == "np" || $('select#form-select-storage-vm-public-nic1 option:checked').val() == $('select#form-select-storage-vm-cluster-nic1 option:checked').val()){
+    }else if(svnt == "np" && $('select#form-select-storage-vm-public-nic1 option:checked').val() == $('select#form-select-storage-vm-cluster-nic1 option:checked').val()){
         alert("NIC Passthrough 스토리지 트래픽 구성 값을 다르게 입력해주세요.");
         valicate_check = false;
-    }else if(svnt == "npb" || uniq_nic_cnt == 4){
+    }else if(svnt == "npb" && uniq_nic_cnt == 4){
         alert("NIC Passthrough Bonding 스토리지 트래픽 구성 값을 다르게 입력해주세요.");
         valicate_check = false;
     }else if($('#form-input-storage-vm-hosts-file').val() == ""){

--- a/src/features/storage-vm-wizard.js
+++ b/src/features/storage-vm-wizard.js
@@ -1102,9 +1102,6 @@ function validateStorageVm(){
     var svnt = $('input[type=radio][name=form-radio-storage-vm-nic-type]:checked').val();
     var uniq_nic_cnt = Array.from(new Set([$('select#form-select-storage-vm-public-nic1 option:checked').val(),$('select#form-select-storage-vm-cluster-nic1 option:checked').val(),$('select#form-select-storage-vm-public-nic2 option:checked').val(),$('select#form-select-storage-vm-cluster-nic2 option:checked').val()]));
 
-    alert(aaa);
-    alert(aaa.length);
-
     var disk_select_cnt = 0;
     $('input[type=checkbox][name="form-checkbox-disk"]').each(function() {
         if(this.checked){

--- a/src/features/storage-vm-wizard.js
+++ b/src/features/storage-vm-wizard.js
@@ -709,12 +709,14 @@ function setDiskInfo(){
                 for(var i = 0 ; i < lun_pci_list.length ; i ++ ){
                     
                     var partition_text = '';
+                    var check_disable = '';
                     if( lun_pci_list[i].children != undefined){
                         partition_text = '( Partition exists count : '+lun_pci_list[i].children.length+' )';
+                        var check_disable = 'disabled';
                     }
 
                     el += '<div class="pf-c-check">';
-                    el += '<input class="pf-c-check__input" type="checkbox" id="form-checkbox-disk'+i+'" name="form-checkbox-disk" value=/dev/'+lun_pci_list[i].name+' />';
+                    el += '<input class="pf-c-check__input" type="checkbox" id="form-checkbox-disk'+i+'" name="form-checkbox-disk" value="/dev/'+lun_pci_list[i].name+'" '+check_disable+' />';
                     el += '<label class="pf-c-check__label" style="margin-top:5px" for="form-checkbox-disk'+i+'">/dev/'+lun_pci_list[i].name+' '+lun_pci_list[i].state+' '+lun_pci_list[i].size+' '+lun_pci_list[i].model+' '+partition_text+'</label>';
                     el += '</div>';    
                 }
@@ -1096,8 +1098,12 @@ function setReviewInfo(){
  * History  : 2021.03.17 최초 작성
  */
 function validateStorageVm(){
-    var valicateCheck = true;
+    var valicate_check = true;
     var svnt = $('input[type=radio][name=form-radio-storage-vm-nic-type]:checked').val();
+    var uniq_nic_cnt = Array.from(new Set([$('select#form-select-storage-vm-public-nic1 option:checked').val(),$('select#form-select-storage-vm-cluster-nic1 option:checked').val(),$('select#form-select-storage-vm-public-nic2 option:checked').val(),$('select#form-select-storage-vm-cluster-nic2 option:checked').val()]));
+
+    alert(aaa);
+    alert(aaa.length);
 
     var disk_select_cnt = 0;
     $('input[type=checkbox][name="form-checkbox-disk"]').each(function() {
@@ -1108,79 +1114,85 @@ function validateStorageVm(){
 
     if($('select#form-select-storage-vm-cpu option:checked').val() == ""){ //cpu
         alert("CPU를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if($('select#form-select-storage-vm-memory option:checked').val() == ""){ //memory
         alert("Memory를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(disk_select_cnt == 0){
         alert("디스크를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if($('select#form-select-storage-vm-mngt-nic option:checked').val() == ""){
         alert("관리 NIC용 Bridge를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(svnt == "npb" && $('select#form-select-storage-vm-public-nic1 option:checked').val() == ""){
         alert("서버용 NIC 1번을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(svnt == "npb" && $('select#form-select-storage-vm-public-nic2 option:checked').val() == ""){
         alert("서버용 NIC 2번을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(svnt == "npb" && $('select#form-select-storage-vm-cluster-nic1 option:checked').val() == ""){
         alert("복제용 NIC 1번을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(svnt == "npb" && $('select#form-select-storage-vm-cluster-nic2 option:checked').val() == ""){
         alert("복제용 NIC 2번을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(svnt != "npb" && $('select#form-select-storage-vm-public-nic1 option:checked').val() == ""){
         alert("서버용 NIC 1번을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(svnt != "npb" && $('select#form-select-storage-vm-cluster-nic1 option:checked').val() == ""){
         alert("복제용 NIC 1번을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
+    }else if(svnt == "np" || $('select#form-select-storage-vm-public-nic1 option:checked').val() == $('select#form-select-storage-vm-cluster-nic1 option:checked').val()){
+        alert("NIC Passthrough 스토리지 트래픽 구성 값을 다르게 입력해주세요.");
+        valicate_check = false;
+    }else if(svnt == "npb" || uniq_nic_cnt == 4){
+        alert("NIC Passthrough Bonding 스토리지 트래픽 구성 값을 다르게 입력해주세요.");
+        valicate_check = false;
     }else if($('#form-input-storage-vm-hosts-file').val() == ""){
         alert("Hosts 파일을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if($("#form-input-storage-vm-hostname").val() == ""){
         alert("호스트명을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if($("#form-input-storage-vm-mgmt-ip").val()  == ""){
         alert("관리 NIC IP를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if($("#form-input-storage-vm-mgmt-gw").val() == ""){
         alert("관리 NIC Gateway를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if($("#form-input-storage-vm-public-ip").val() == ""){
         alert("스토리지 서버 NIC IP를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if($("#form-input-storage-vm-cluster-ip").val() == ""){
         alert("스토리지 복제 NIC IP를 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if($('#form-input-storage-vm-ssh-private-key-file').val() == ""){
         alert("SSH 개인 Key 파일을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if($('#form-input-storage-vm-ssh-public-key-file').val() == ""){
         alert("SSH 공개 Key 파일을 입력해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(!checkHostFormat($("#form-input-storage-vm-hostname").val())){
         alert("호스트명 입력 형식을 확인해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(!checkCidrFormat($("#form-input-storage-vm-mgmt-ip").val())){
         alert("관리 NIC IP 형식을 확인해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(!checkIp($("#form-input-storage-vm-mgmt-gw").val())){
         alert("관리 NIC Gateway 형식을 확인해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(!checkCidrFormat($("#form-input-storage-vm-public-ip").val())){
         alert("스토리지 서버 NIC IP 형식을 확인해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(!checkCidrFormat($("#form-input-storage-vm-cluster-ip").val())){
         alert("스토리지 복제 NIC IP 형식을 확인해주세요.");
-        valicateCheck = false;
+        valicate_check = false;
     }else if(!checkSpace($("#form-textarea-storage-vm-hosts-file").val())){
         alert("Hosts 파일 작성 시 'Tab 키'만 사용 가능합니다.");
-        valicateCheck = false;
+        valicate_check = false;
     }
 
-    return valicateCheck;
+    return valicate_check;
 }
 
 /**


### PR DESCRIPTION
#211 #212 

- [x] scvm, ccvm 배포 마법사 관련 python 함수명 잘못 표기되어 있는 부분 개선 및 host ping 테스트 개선
- [x] scvm, ccvm 벨리데이션 강화 및 변수명 수정

상세 수정 사항
1. scvm, ccvm 배포 마법사 관련 함수명 오기된 부분 수정
2. host_ping_test.py에 ssh 명령시 yes/no 핑거 프린트 부문 해결을 위해 실행하는 호스트에서 pcs 구성할 1,2,3 호스트에 1회씩 echo 명령어 수행하여 known_hosts에 등록 될수 있도록 개선
3. scvm 배포 마법사 lun passthrough 목록중 파티션이 존재하면 선택 불가하도록 수정
4. 스토리지 트래픽 구성중 nic passthrough 또는 nic passthrough bonding 일 경우 중복 선택시 알림 기능 추가
5. scvm, ccvm jsv파일중 valicateCheck를 valicate_check로 변경