### PR TITLE
클러스터 준비 마법사 - SSH Key 임시 파일 사용, 호스트 프로파일, 시간서버 단계에서의 기능 개선 및 버그 수정

### DIFF
--- a/src/features/cluster-config-prepare.js
+++ b/src/features/cluster-config-prepare.js
@@ -669,6 +669,8 @@ async function resetClusterConfigWizardWithData() {
     $('input[name=form-input-cluster-config-ssh-key-file]').val("");
     $('textarea[name=div-textarea-cluster-config-temp-new-ssh-key-file]').val("");
     $('textarea[name=div-textarea-cluster-config-temp-existing-ssh-key-file]').val("");
+    cockpit.script(["rm -f /root/.ssh/temp_id_rsa"])
+    cockpit.script(["rm -f /root/.ssh/temp_id_rsa.pub"])
     // hosts
     $('#form-radio-hosts-new').prop('checked', true);
     $('#form-radio-hosts-file').prop('checked', false);
@@ -1084,7 +1086,6 @@ async function modifyTimeServer(timeserver_confirm_ip_text, file_type, timeserve
     cockpit.script(["sed -i '/^server /d' /" + chrony_file_root + ""])
     cockpit.script(["sed -i '/^pool /d' /" + chrony_file_root + ""])
 
-    // chrony.conf 파일에서 서버 추가하는 부분
     // 외부 시간 서버
     if (file_type == "external") {
         // chrony.conf 파일 서버 리스트 부분 초기화
@@ -1098,7 +1099,7 @@ async function modifyTimeServer(timeserver_confirm_ip_text, file_type, timeserve
         for (let i in timeserver_confirm_ip_text) {
             cockpit.script(["sed -i'' -r -e \"/# Please consider joining the pool/a\\server " + timeserver_confirm_ip_text[i] + " iburst minpoll 0 maxpoll 0\" /" + chrony_file_root + ""])
         }
-        let allow_ip = "100.100.0.0/24";
+        let allow_ip = "100.100.0.0/16";
         cockpit.script(["sed -i'' -r -e \"/# Allow NTP client access from local network/a\\allow " + allow_ip + "\" /" + chrony_file_root + ""])
     }
     // 로컬 시간 서버
@@ -1120,15 +1121,14 @@ async function modifyTimeServer(timeserver_confirm_ip_text, file_type, timeserve
             cockpit.script(["sed -i'' -r -e \"/# Please consider joining the pool/a\\server " + timeserver_confirm_ip_text[0] + " iburst minpoll 0 maxpoll 0\" /" + chrony_file_root + ""])
         }
         // 공통 수정 부분
-        let allow_ip = timeserver_confirm_ip_text[0];
-        allow_ip = allow_ip.split('.');
-        allow_ip = allow_ip[0] + "." + allow_ip[1] + "." + allow_ip[2] + ".0/24";
+        let allow_ip = "100.100.0.0/16";
         cockpit.script(["sed -i'' -r -e \"/# Allow NTP client access from local network/a\\allow " + allow_ip + "\" /" + chrony_file_root + ""])
         cockpit.script(["sed -i'' -r -e \"/# Serve time even if not synchronized to a time source/a\\local stratum 10\" /" + chrony_file_root + ""])
         // chronyd restart
         cockpit.script(["systemctl restart chronyd"])
     }
 }
+
 
 
 /**

--- a/src/features/cluster-config-prepare.js
+++ b/src/features/cluster-config-prepare.js
@@ -393,11 +393,11 @@ $('#form-input-cluster-config-host-number, #form-input-cluster-config-host-numbe
         }
         for (let i = 1; i <= current_val; i++) {
             let sum = 10 + i;
-            host_ip_info = host_ip_info + "100.100.0." + sum + "\tscvm" + i + "\n";
+            host_ip_info = host_ip_info + "100.100.10." + sum + "\tscvm" + i + "\n";
         }
         for (let i = 1; i <= current_val; i++) {
             let sum = 10 + i;
-            host_ip_info = host_ip_info + "100.200.0." + sum + "\tscvm" + i + "-cn\n";
+            host_ip_info = host_ip_info + "100.200.10." + sum + "\tscvm" + i + "-cn\n";
         }
         target_textarea.val(host_ip_info);
     } else {

--- a/src/features/cluster-config-prepare.js
+++ b/src/features/cluster-config-prepare.js
@@ -249,7 +249,7 @@ $('#button-next-step-modal-wizard-cluster-config-prepare').on('click', function 
             $('#button-next-step-modal-wizard-cluster-config-prepare').attr('disabled', false);
             $('#button-before-step-modal-wizard-cluster-config-prepare').attr('disabled', false);
             cur_step_wizard_cluster_config_prepare = "6";
-        }else {
+        } else {
             $('#button-next-step-modal-wizard-cluster-config-prepare').html('완료');
             $('#div-modal-wizard-cluster-config-review').show();
             $('#nav-button-cluster-config-review').addClass('pf-m-current');
@@ -258,11 +258,11 @@ $('#button-next-step-modal-wizard-cluster-config-prepare').on('click', function 
             cur_step_wizard_cluster_config_prepare = "5";
         }
     } else if (cur_step_wizard_cluster_config_prepare == "6") {
-            resetClusterConfigWizard();
-            resetClusterConfigWizardWithData();
-            cur_step_wizard_cluster_config_prepare = "1";
-            // 페이지 새로고침
-            location.reload();
+        resetClusterConfigWizard();
+        resetClusterConfigWizardWithData();
+        cur_step_wizard_cluster_config_prepare = "1";
+        // 페이지 새로고침
+        location.reload();
     }
 });
 
@@ -733,7 +733,7 @@ async function resetClusterConfigWizardWithData() {
 
 function generateSshkey() {
     return new Promise(function (resolve) {
-        resolve(cockpit.script(["ssh-keygen -t rsa -b 2048 -f /root/.ssh/id_rsa -N '' <<<y 2>&1 >/dev/null"]));
+        resolve(cockpit.script(["ssh-keygen -t rsa -b 2048 -f /root/.ssh/temp_id_rsa -N '' <<<y 2>&1 >/dev/null"]));
     });
 }
 
@@ -751,7 +751,7 @@ function generateSshkey() {
 async function readSshKeyFile() {
     await generateSshkey();
     // 개인키 읽어오기
-    cockpit.file("/root/.ssh/id_rsa").read()
+    cockpit.file("/root/.ssh/temp_id_rsa").read()
         .done(function (tag) {
             // console.log(tag);
             // ssh_key_textarea에 텍스트 삽입
@@ -760,7 +760,7 @@ async function readSshKeyFile() {
         .fail(function (error) {
         });
     // 공개키 읽어오기
-    cockpit.file("/root/.ssh/id_rsa.pub").read()
+    cockpit.file("/root/.ssh/temp_id_rsa.pub").read()
         .done(function (tag) {
             // console.log(tag);
             // ssh_key_textarea에 텍스트 삽입
@@ -986,6 +986,10 @@ async function writeSshKeyFile(text1, text2) {
     cockpit.script(["mv -f /root/.ssh/authorized_keys{.uniq}"])
     cockpit.script(["chmod 644 /root/.ssh/authorized_keys"])
     cockpit.script(["rm -f /root/.ssh/authorized_keys.uniq"])
+
+    // 임시 키 파일 삭제
+    cockpit.script(["rm -f /root/.ssh/temp_id_rsa"])
+    cockpit.script(["rm -f /root/.ssh/temp_id_rsa.pub"])
 }
 
 
@@ -1071,7 +1075,7 @@ function checkHostName() {
  * Description : 클러스터 준비 마법사에서 완료를 누를 때 설정확인 메뉴에서 확인했던 time server 정보대로 host에 업데이트하는 함수
  * Parameter : timeserver_confirm_ip_text(설정확인 단계에서의 ip주소 값), file_type(외부 또는 로컬서버) , timeserver_current_host_num(현재 설정 중인 호스트 번호)
  * Return  : 없음
- * History  : 2021.03.24 최초 작성
+ * History  : 2021.04.12 수정
  **/
 
 async function modifyTimeServer(timeserver_confirm_ip_text, file_type, timeserver_current_host_num) {
@@ -1116,12 +1120,13 @@ async function modifyTimeServer(timeserver_confirm_ip_text, file_type, timeserve
             cockpit.script(["sed -i'' -r -e \"/# Please consider joining the pool/a\\server " + timeserver_confirm_ip_text[0] + " iburst minpoll 0 maxpoll 0\" /" + chrony_file_root + ""])
         }
         // 공통 수정 부분
-        // let allow_ip = timeserver_confirm_ip_text[0];
-        // allow_ip = allow_ip.split('.');
-        // allow_ip = allow_ip[0] + "." + allow_ip[1] + ".0.0/24";
-        let allow_ip = "100.100.0.0/24";
+        let allow_ip = timeserver_confirm_ip_text[0];
+        allow_ip = allow_ip.split('.');
+        allow_ip = allow_ip[0] + "." + allow_ip[1] + "." + allow_ip[2] + ".0/24";
         cockpit.script(["sed -i'' -r -e \"/# Allow NTP client access from local network/a\\allow " + allow_ip + "\" /" + chrony_file_root + ""])
         cockpit.script(["sed -i'' -r -e \"/# Serve time even if not synchronized to a time source/a\\local stratum 10\" /" + chrony_file_root + ""])
+        // chronyd restart
+        cockpit.script(["systemctl restart chronyd"])
     }
 }
 
@@ -1133,7 +1138,7 @@ async function modifyTimeServer(timeserver_confirm_ip_text, file_type, timeserve
  * Description : 클러스터 준비 마법사에서 완료를 누를 때 유효성 검사하는 함수
  * Parameter : timeserver_type(시간서버 타입에 따라 필수 입력 값이 달라져 구분하기 위한 값)
  * Return  : 없음
- * History  : 2021.03.25 최초 작성
+ * History  : 2021.04.12 수정
  */
 function validateClusterConfigPrepare(timeserver_type) {
 
@@ -1142,9 +1147,9 @@ function validateClusterConfigPrepare(timeserver_type) {
     let timeserver_ip_check_external_1 = checkHostFormat($('#div-cluster-config-confirm-time-server-1').text());
     let timeserver_ip_check_external_2 = checkHostFormat($('#div-cluster-config-confirm-time-server-2').text());
     let timeserver_ip_check_external_3 = checkHostFormat($('#div-cluster-config-confirm-time-server-3').text());
-    let timeserver_ip_check_internal_1 = checkIp($('#div-cluster-config-confirm-time-server-1').text());
-    let timeserver_ip_check_internal_2 = checkIp($('#div-cluster-config-confirm-time-server-2').text());
-    let timeserver_ip_check_internal_3 = checkIp($('#div-cluster-config-confirm-time-server-3').text());
+    let timeserver_ip_check_internal_1 = checkHostFormat($('#div-cluster-config-confirm-time-server-1').text());
+    let timeserver_ip_check_internal_2 = checkHostFormat($('#div-cluster-config-confirm-time-server-2').text());
+    let timeserver_ip_check_internal_3 = checkHostFormat($('#div-cluster-config-confirm-time-server-3').text());
 
     if ($('#div-textarea-cluster-config-confirm-ssh-key-pri-file').val().trim() == "") {
         alert("SSH 개인 키 파일 정보를 확인해 주세요.");
@@ -1171,13 +1176,13 @@ function validateClusterConfigPrepare(timeserver_type) {
         }
     } else if (timeserver_type == "internal") {
         if (timeserver_ip_check_internal_1 == false) {
-            alert("시간 서버 1번 IP정보를 확인해 주세요. IP 형식으로만 입력 가능합니다.");
+            alert("시간 서버 1번 정보를 확인해 주세요.");
             validate_check = false;
         } else if (timeserver_ip_check_internal_2 == false) {
-            alert("시간 서버 2번 IP정보를 확인해 주세요. IP 형식으로만 입력 가능합니다.");
+            alert("시간 서버 2번 정보를 확인해 주세요.");
             validate_check = false;
         } else if (timeserver_ip_check_internal_3 == false) {
-            alert("시간 서버 3번 IP정보를 확인해 주세요. IP 형식으로만 입력 가능합니다.");
+            alert("시간 서버 3번 정보를 확인해 주세요.");
             validate_check = false;
         }
     }


### PR DESCRIPTION
## 클러스터 준비 마법사 - 키 생성 시점 변경 및 임시 파일 사용

#### 연관 이슈 - 클러스터 준비 마법사 - 키 생성 시점 변경 및 임시 파일 사용 #206

- [x] 클러스터 준비 마법사에서 키를 새로 생성할 때 임시 파일을 만들어 최종 배포가 완료되면 "id_rsa"의 파일은 생성되고 임시파일은 삭제되는 방식으로 변경
- [x] 마법사 취소 시 임시 키 파일 삭제 처리



## 클러스터 준비 마법사-호스트 프로파일-기본 값 변경

#### 연관 이슈 - 클러스터 준비 마법사-호스트 프로파일-기본 값 변경-버그 수정 #205

- [x] 클러스터 준비 마법사의 호스트 프로파일 단계에서 템플릿 값 변경



## 클러스터 준비 마법사-시간서버 버그 수정

#### 연관 이슈 - 클러스터 준비 마법사-시간서버-버그 수정 #204

- [x] chrony.conf 파일의 allow 섹션 값 수정
- [x] 적용된 값으로 chrony 서비스 다시시작 기능 추가
- [x] 시간서버 (로컬)의 입력 값의 validation 수정

#### 특이 사항
chrony.conf 파일의 allow 섹션 값 수정 이슈 관련
호스트 프로파일 정보가 담겨있는 textarea의 텍스트 값으로
chrony.conf allow 부분을 자동으로 설정하는 기능은 
테스트가 더 필요하여 현재는 고정 값 "100.100.0.0/16"으로 설정하였습니다.