### PR TITLE
클러스터 준비 마법사 - 시간서버 - 설정 값 변경 (추가 수정)

### DIFF
--- a/src/features/cluster-config-prepare.js
+++ b/src/features/cluster-config-prepare.js
@@ -1121,7 +1121,7 @@ async function modifyTimeServer(timeserver_confirm_ip_text, file_type, timeserve
             cockpit.script(["sed -i'' -r -e \"/# Please consider joining the pool/a\\server " + timeserver_confirm_ip_text[0] + " iburst minpoll 0 maxpoll 0\" /" + chrony_file_root + ""])
         }
         // 공통 수정 부분
-        let allow_ip = "100.100.0.0/16";
+        let allow_ip = "0.0.0.0/0";
         cockpit.script(["sed -i'' -r -e \"/# Allow NTP client access from local network/a\\allow " + allow_ip + "\" /" + chrony_file_root + ""])
         cockpit.script(["sed -i'' -r -e \"/# Serve time even if not synchronized to a time source/a\\local stratum 10\" /" + chrony_file_root + ""])
         // chronyd restart


### PR DESCRIPTION
## 클러스터 준비 마법사 - 시간서버 - 설정 값 변경 (추가 수정)

연관 이슈: 클러스터 준비 마법사 - 시간서버 - 설정 값 변경 (추가 수정) #240

- [x] 클러스터 준비 마법사의 시간서버 설정 값 변경으로 chrony.conf의 allow의 값을 "0.0.0.0/0"으로 변경

#### 빠튼린 부분 추가 수정 하였습니다.