### PR TITLE
#252 ipcorrector가 scvm의 crontab에 정상적으로 적용 안되는 문제 해결

### DIFF
--- a/shell/host/ipcorrector
+++ b/shell/host/ipcorrector
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+LANG=en_US.utf-8
+LANGUAGE=en
+PROMETHEUS_HOST=$(ceph orch ps |grep prome  |awk {'print $2'})
+GRAFANA_HOST=$(ceph orch ps |grep grafana  |awk {'print $2'})
+ALERTMANAGER_HOST=$(ceph orch ps |grep alertmanager  |awk {'print $2'})
+
+PROMETHEUS_IP=$(cat /etc/hosts | grep $PROMETHEUS_HOST-mngt |awk {'print $1'})
+GRAFANA_IP=$(cat /etc/hosts | grep $GRAFANA_HOST-mngt |awk {'print $1'})
+ALERTMANAGER_IP=$(cat /etc/hosts | grep $ALERTMANAGER_HOST-mngt |awk {'print $1'})
+
+
+date                    | tee -a /var/log/ceph/ip.log
+echo "$GRAFANA_HOST     | $GRAFANA_IP"          | tee -a /var/log/ceph/ip.log
+echo "$ALERTMANAGER_HOST        | $ALERTMANAGER_IP"     | tee -a /var/log/ceph/ip.log
+echo "$PROMETHEUS_HOST  | $PROMETHEUS_IP"       | tee -a /var/log/ceph/ip.log
+
+ceph config set mgr mgr/dashboard/ALERTMANAGER_API_HOST http://$ALERTMANAGER_IP:9093
+ceph config set mgr mgr/dashboard/GRAFANA_API_URL https://$GRAFANA_IP:3000
+ceph config set mgr mgr/dashboard/PROMETHEUS_API_HOST http://$PROMETHEUS_IP:9095

--- a/shell/host/scvm_bootstrap.sh
+++ b/shell/host/scvm_bootstrap.sh
@@ -54,9 +54,9 @@ cephadm --image "$image" bootstrap \
         ceph config set client rbd_cache_target_dirty 536870912 && \
         ceph config set client rbd_cache_max_dirty_age 5.0
 
-crontab<<EOF
-* * * * * /usr/local/bin/ipcorrector
-EOF
+#crontab<<EOF
+#* * * * * /usr/local/bin/ipcorrector
+#EOF
 sed -e '/mon host/d' /etc/ceph/ceph.conf | sed -e 's/mon_host/mon host/' > /etc/ceph/ceph.conf_
 cp /etc/ceph/ceph.conf_ /etc/ceph/ceph.conf
 for host in $allhosts
@@ -68,6 +68,11 @@ do
   ssh -o StrictHostKeyChecking=no $host rm -rf /root/bootstrap.sh
 done
 
+for host in $scvms
+
+do
+  ssh $host "(crontab -l 2>/dev/null; echo \"* * * * * /usr/local/bin/ipcorrector\") | crontab -"
+done
 
 for host in $scvms
 do

--- a/tools/cloudinit/gencloudinit.py
+++ b/tools/cloudinit/gencloudinit.py
@@ -398,7 +398,17 @@ def scvmGen(pn_nic=None, pn_ip=None, pn_prefix=24, cn_nic=None, cn_ip=None, cn_p
                 'permissions': '0777'
             }
         )
-
+    with open(f'{pluginpath}/shell/host/ipcorrector', 'rt') as ipcorrectorfile:
+        ipcorrector = ipcorrectorfile.read()
+        yam2['write_files'].append(
+            {
+                'encoding': 'base64',
+                'content': base64.encodebytes(ipcorrector.encode()),
+                'owner': 'root:root',
+                'path': '/usr/local/bin/ipcorrector',
+                'permissions': '0777'
+            }
+        )
     with open(f'{tmpdir}/user-data', 'wt') as f:
         f.write('#cloud-config\n')
         f.write(yaml.dump(yam2).replace("\n\n", "\n"))


### PR DESCRIPTION

#252 ipcorrector가 scvm의 crontab에 정상적으로 적용 안되는 문제 해결

template을 새로 생성하지 않아도 ipcorrector를 업데이트 할 수 있도록 cloud-init으로 배포하도록 변경