### PR TITLE
pg_autoscaler 값 변경(to scale-up)

### DIFF
--- a/shell/host/scvm_bootstrap.sh
+++ b/shell/host/scvm_bootstrap.sh
@@ -97,6 +97,7 @@ ceph mgr module disable dashboard
 ceph mgr module enable dashboard
 
 ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false
+ceph config set mgr mgr/pg_autoscaler/autoscale_profile scale-up
 
 /usr/bin/mv -f /usr/share/ablestack/ablestack-wall/process-exporter/scvm_process.yml /usr/share/ablestack/ablestack-wall/process-exporter/process.yml
 


### PR DESCRIPTION
### PR 설명

#301 

이 PR은 ceph 매니저 모듈 중 pg_autoscale의 값이 scale-down으로 기본 설정되어 있어 초기 pg 값이 세팅되고 나면 커지지 않아 이미지 등을 rbd에 쓸 때 시스템이 정상 동작하지 않는 오류를 수정하였습니다.
bootstrap 단계에서 pg_autoscale의 값을 scale-up으로 변경합니다.

<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [x] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [x] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 소규모 기능/개선

#### 버그 심각도

- [x] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)



### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


