### PR TITLE
SCVM 모니터 설정 버그 및 컨테이너 이미지 REPO 변경

### DIFF
--- a/shell/host/scvm_bootstrap.sh
+++ b/shell/host/scvm_bootstrap.sh
@@ -57,7 +57,9 @@ cephadm --image "$image" bootstrap \
 #crontab<<EOF
 #* * * * * /usr/local/bin/ipcorrector
 #EOF
-sed -e '/mon host/d' /etc/ceph/ceph.conf | sed -e 's/mon_host/mon host/' > /etc/ceph/ceph.conf_
+#sed -e '/mon host/d' /etc/ceph/ceph.conf | sed -e 's/mon_host/mon host/' > /etc/ceph/ceph.conf_
+grep fsid /etc/ceph/ceph.conf >> /root/ceph.conf
+sed -e '/mon_host/d' /root/ceph.conf > /etc/ceph/ceph.conf_
 cp /etc/ceph/ceph.conf_ /etc/ceph/ceph.conf
 for host in $allhosts
 do
@@ -98,6 +100,13 @@ ceph mgr module enable dashboard
 
 ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false
 ceph config set mgr mgr/pg_autoscaler/autoscale_profile scale-up
+
+ceph config set mgr mgr/cephadm/container_image_alertmanager docker.io/prom/alertmanager:ablestack
+ceph config set mgr mgr/cephadm/container_image_grafana docker.io/ceph/ceph-grafana:ablestack
+ceph config set mgr mgr/cephadm/container_image_node_exporter docker.io/prom/node-exporter:ablestack
+ceph config set mgr mgr/cephadm/container_image_prometheus docker.io/prom/prometheus:ablestack
+
+
 
 /usr/bin/mv -f /usr/share/ablestack/ablestack-wall/process-exporter/scvm_process.yml /usr/share/ablestack/ablestack-wall/process-exporter/process.yml
 

--- a/shell/host/scvm_bootstrap.sh
+++ b/shell/host/scvm_bootstrap.sh
@@ -52,7 +52,11 @@ cephadm --image "$image" bootstrap \
         ceph config set client rbd_cache_size 1073741824 && \
         ceph config set client rbd_cache_max_dirty 805306368 && \
         ceph config set client rbd_cache_target_dirty 536870912 && \
-        ceph config set client rbd_cache_max_dirty_age 5.0
+        ceph config set client rbd_cache_max_dirty_age 5.0 && \
+        ceph config set mgr mgr/cephadm/container_image_alertmanager localhost:5000/prom/alertmanager:ablestack && \
+        ceph config set mgr mgr/cephadm/container_image_grafana localhost:5000/ceph/ceph-grafana:ablestack && \
+        ceph config set mgr mgr/cephadm/container_image_node_exporter localhost:5000/prom/node-exporter:ablestack && \
+        ceph config set mgr mgr/cephadm/container_image_prometheus localhost:5000/prom/prometheus:ablestack
 
 #crontab<<EOF
 #* * * * * /usr/local/bin/ipcorrector
@@ -100,13 +104,6 @@ ceph mgr module enable dashboard
 
 ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false
 ceph config set mgr mgr/pg_autoscaler/autoscale_profile scale-up
-
-ceph config set mgr mgr/cephadm/container_image_alertmanager docker.io/prom/alertmanager:ablestack
-ceph config set mgr mgr/cephadm/container_image_grafana docker.io/ceph/ceph-grafana:ablestack
-ceph config set mgr mgr/cephadm/container_image_node_exporter docker.io/prom/node-exporter:ablestack
-ceph config set mgr mgr/cephadm/container_image_prometheus docker.io/prom/prometheus:ablestack
-
-
 
 /usr/bin/mv -f /usr/share/ablestack/ablestack-wall/process-exporter/scvm_process.yml /usr/share/ablestack/ablestack-wall/process-exporter/process.yml
 


### PR DESCRIPTION
### PR 설명

이 PR은 SCVM bootstrap 시 모니터 설정이 SCVM1만 설정되는 오류를 수정했습니다.
컨테이너 이미지 repo를 docker.io에서 로컬호스트로 변경하여 인터넷이 되지 않는 네트워크에서도 컨테이너 이미지를 받아올 수 있도록 변경했습니다.
<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)


### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 소규모 기능/개선

#### 버그 심각도

- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


